### PR TITLE
refactor api for better simple value checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A preconditions library for TypeScript.
 ## Examples
 
 ```ts
-import { optionalNumber, optionalString } from 'preconditions-ts';
+import { optionalNumberFrom, optionalStringFrom } from 'preconditions-ts';
 
 const test = { foo: 'bar' };
-optionalString(test, 'foo'); // Maybe<string> (OK)
-optionalNumber(test, 'foo'); // Maybe<number> (THROWS)
+optionalStringFrom(test, 'foo'); // Maybe<string> (OK)
+optionalNumberFrom(test, 'foo'); // Maybe<number> (THROWS)
 ```
 
 ## LICENSE

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -1,5 +1,5 @@
-import { optionalNumber, optionalString } from '../';
+import { optionalNumberFrom, optionalStringFrom } from '../';
 
 const test = { foo: 'bar' };
-optionalString(test, 'foo'); // Maybe<string> (OK)
-optionalNumber(test, 'foo'); // Maybe<number> (THROWS)
+optionalStringFrom(test, 'foo'); // Maybe<string> (OK)
+optionalNumberFrom(test, 'foo'); // Maybe<number> (THROWS)

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,7 @@
 import {
   DataSource,
+  optional as coreOptional,
+  required as coreRequired,
   optionalOfType,
   requiredOfType,
   isNumber,
@@ -9,48 +11,99 @@ import {
 } from './core';
 
 export const optionalNumber = (
-  d: DataSource,
-  key: string,
+  value: any,
   errorMessage?: string
-) => optionalOfType(d, key, isNumber, errorMessage);
+) => coreOptional(value, isNumber, errorMessage);
 
 export const optionalString = (
+  value: any,
+  errorMessage?: string
+) => coreOptional(value, isString, errorMessage);
+
+export const optionalBoolean = (
+  value: any,
+  errorMessage?: string
+) => coreOptional(value, isBoolean, errorMessage);
+
+export const optionalArray = (
+  value: any,
+  errorMessage?: string
+) => coreOptional(value, isArray, errorMessage);
+
+export const optionalNumberFrom = <DS = DataSource>(
+  d: DS,
+  key: keyof DS,
+  errorMessage?: string
+) => optionalOfType<number, DS>(d, key, isNumber, errorMessage);
+
+export const optionalStringFrom = (
   d: DataSource,
   key: string,
   errorMessage?: string
 ) => optionalOfType(d, key, isString, errorMessage);
 
-export const optionalBoolean = (
+export const optionalBooleanFrom = (
   d: DataSource,
   key: string,
   errorMessage?: string
 ) => optionalOfType(d, key, isBoolean, errorMessage);
 
-export const optionalArray = (
+export const optionalArrayFrom = (
   d: DataSource,
   key: string,
   errorMessage?: string
 ) => optionalOfType(d, key, isArray, errorMessage);
 
+export const required = <T>(
+  value?: any,
+  errorMessage?: string,
+): T => {
+  if (value == null) {
+    throw new Error(errorMessage || 'value required');
+  }
+
+  return value;
+}
+
 export const requiredNumber = (
+  value: any,
+  errorMessage?: string
+) => coreRequired(value, isNumber, errorMessage);
+
+export const requiredString = (
+  value: any,
+  errorMessage?: string
+) => coreRequired(value, isString, errorMessage);
+
+export const requiredBoolean = (
+  value: any,
+  errorMessage?: string
+) => coreRequired(value, isBoolean, errorMessage);
+
+export const requiredArray = (
+  value: any,
+  errorMessage?: string
+) => coreRequired(value, isArray, errorMessage);
+
+export const requiredNumberFrom = (
   d: DataSource,
   key: string,
   errorMessage?: string
 ) => requiredOfType(d, key, isNumber, errorMessage);
 
-export const requiredString = (
+export const requiredStringFrom = (
   d: DataSource,
   key: string,
   errorMessage?: string
 ) => requiredOfType(d, key, isString, errorMessage);
 
-export const requiredBoolean = (
+export const requiredBooleanFrom = (
   d: DataSource,
   key: string,
   errorMessage?: string
 ) => requiredOfType(d, key, isBoolean, errorMessage);
 
-export const requiredArray = (
+export const requiredArrayFrom = (
   d: DataSource,
   key: string,
   errorMessage?: string

--- a/test/optional.api.spec.ts
+++ b/test/optional.api.spec.ts
@@ -1,0 +1,66 @@
+import { Expect as expect, Setup, Test, TestCase } from 'alsatian';
+import { optionalNumberFrom, optionalNumber } from '../index';
+
+export class OptionalApiValidationFixture {
+  private testStructure: { [key: string]: any };
+
+  @Setup
+  public setup() {
+    this.testStructure = {
+      test: 'foo',
+    };
+  }
+
+  @Test('optional number, simple value')
+  @TestCase()
+  public undefinedValue(input: any) {
+    const value = optionalNumber(input);
+    expect(value).not.toBeDefined();
+  }
+
+  @Test('optional number, value found type assertion ok')
+  @TestCase(5)
+  public validSimpleType(input: any) {
+    const value = optionalNumber(input);
+    expect(value).toEqual(input);
+  }
+
+  @Test('optional number, type mismatch')
+  @TestCase('foo')
+  public invalidSimpleType(input: any) {
+    expect(() => {
+      optionalNumber(input);
+    }).toThrowError(Error, 'invalid type of value detected');
+  }
+
+  @Test('optional number, type mismatch, custom error')
+  @TestCase('foo', 'not working')
+  public invalidSimpleTypeCustomError(input: any, errorMessage: string) {
+    expect(() => {
+      optionalNumber(input, errorMessage);
+    }).toThrowError(Error, errorMessage);
+  }
+
+  @Test('value not found, optional so ok')
+  @TestCase('foo')
+  public valueNotFound(key: string) {
+    const value = optionalNumberFrom(this.testStructure, key);
+    expect(value).not.toBeDefined();
+  }
+
+  @Test('value found, type mismatch, not ok')
+  @TestCase('test')
+  public typeMismatch(key: string) {
+    expect(() => {
+      optionalNumberFrom(this.testStructure, key);
+    }).toThrowError(Error, `invalid type of value detected for ${key}`);
+  }
+
+  @Test('value found, type mismatch, not ok, custom error')
+  @TestCase('test', 'not ok')
+  public typeMismatchCustomError(key: string, errorMessage: string) {
+    expect(() => {
+      optionalNumberFrom(this.testStructure, key, errorMessage);
+    }).toThrowError(Error, errorMessage);
+  }
+}

--- a/test/optional.spec.ts
+++ b/test/optional.spec.ts
@@ -1,5 +1,5 @@
 import { Expect as expect, Setup, Test, TestCase } from 'alsatian';
-import { optionalOfType, requiredOfType, Type, Validator } from '../core';
+import { optionalOfType, Type, Validator } from '../core';
 
 export class OptionalTypeValidationFixture {
   private testStructure: { [key: string]: any };

--- a/test/required.api.spec.ts
+++ b/test/required.api.spec.ts
@@ -1,0 +1,68 @@
+import { Expect as expect, Setup, Test, TestCase } from 'alsatian';
+import { requiredNumberFrom, requiredNumber } from '../index';
+
+export class RequiredApiValidationFixure {
+  private testStructure: { [key: string]: any };
+
+  @Setup
+  public setup() {
+    this.testStructure = {
+      test: 'foo',
+    };
+  }
+
+  @Test('required number, simple value')
+  @TestCase()
+  public undefinedValue(input: any) {
+    expect(() => {
+      requiredNumber(input);
+    }).toThrowError(Error, 'value required');
+  }
+
+  @Test('required number, value found type assertion ok')
+  @TestCase(5)
+  public validSimpleType(input: any) {
+    const value = requiredNumber(input);
+    expect(value).toEqual(input);
+  }
+
+  @Test('required number, type mismatch')
+  @TestCase('foo')
+  public invalidSimpleType(input: any) {
+    expect(() => {
+      requiredNumber(input);
+    }).toThrowError(Error, 'invalid type of value');
+  }
+
+  @Test('required number, type mismatch, custom error')
+  @TestCase('foo', 'not working')
+  public invalidSimpleTypeCustomError(input: any, errorMessage: string) {
+    expect(() => {
+      requiredNumber(input, errorMessage);
+    }).toThrowError(Error, errorMessage);
+  }
+
+  @Test('value not found,')
+  @TestCase('foo')
+  public valueNotFound(key: string) {
+    expect(() => {
+      requiredNumberFrom(this.testStructure, key);
+    }).toThrowError(Error, `value required for key: ${key}`);
+  }
+
+  @Test('value found, type mismatch, not ok')
+  @TestCase('test')
+  public typeMismatch(key: string) {
+    expect(() => {
+      requiredNumberFrom(this.testStructure, key);
+    }).toThrowError(Error, `invalid type of value detected for key: ${key}`);
+  }
+
+  @Test('value found, type mismatch, not ok, custom error')
+  @TestCase('test', 'not ok')
+  public typeMismatchCustomError(key: string, errorMessage: string) {
+    expect(() => {
+      requiredNumberFrom(this.testStructure, key, errorMessage);
+    }).toThrowError(Error, errorMessage);
+  }
+}

--- a/test/required.spec.ts
+++ b/test/required.spec.ts
@@ -16,7 +16,7 @@ export class RequiredTypeValidationFixture {
   public required(key: string, validator: Validator) {
     expect(() => {
       requiredOfType(this.testStructure, key, validator);
-    }).toThrowError(Error, `value required for ${key}`);
+    }).toThrowError(Error, `value required for key: ${key}`);
   }
 
   @Test('required of type, key found but type mismatch')
@@ -24,7 +24,7 @@ export class RequiredTypeValidationFixture {
   public requiredTypeMismatch(key: string, validator: Validator) {
     expect(() => {
       requiredOfType(this.testStructure, key, validator);
-    }).toThrowError(Error, `invalid type of value detected for ${key}`);
+    }).toThrowError(Error, `invalid type of value detected for key: ${key}`);
   }
 
   @Test('required of type, custom error')


### PR DESCRIPTION
Move `optional<ValueType>` to `optional<ValueType>From` as that's actually what it's doing.

`optional<ValueType>` is now just checking a single input value.